### PR TITLE
Allow search engine referrers to have empty queries

### DIFF
--- a/referrer.go
+++ b/referrer.go
@@ -156,8 +156,8 @@ func parseSearch(rawUrl string, u *url.URL) *Search {
 	query := u.Query()
 	if rule, ok := SearchRules[u.Host]; ok {
 		for _, param := range rule.Parameters {
-			if query := query.Get(param); query != "" {
-				return &Search{URL: rawUrl, Domain: rule.Domain, Label: rule.Label, Query: query}
+			if _, present := query[param]; present {
+				return &Search{URL: rawUrl, Domain: rule.Domain, Label: rule.Label, Query: query.Get(param)}
 			}
 		}
 	}
@@ -176,7 +176,7 @@ func fuzzyParseSearch(u *url.URL) *Search {
 	for _, hostPart := range hostParts {
 		if engine, present := SearchEngines[hostPart]; present {
 			for _, param := range engine.Parameters {
-				if search, ok := query[param]; ok && search[0] != "" {
+				if search, ok := query[param]; ok {
 					return &Search{Label: engine.Label, Query: search[0], Domain: u.Host}
 				}
 			}

--- a/referrer_test.go
+++ b/referrer_test.go
@@ -122,8 +122,10 @@ func TestSearchSiteWithEmptyQuery(t *testing.T) {
 	r, err := Parse(url)
 	assert.NoError(t, err)
 
-	_, ok := r.(*Indirect)
-	assert.True(t, ok)
+	engine := r.(*Search)
+	assert.Equal(t, engine.Label, "Google")
+	assert.Equal(t, engine.Domain, "www.google.co.in")
+	assert.Equal(t, engine.Query, "")
 }
 
 func TestDirectSimple(t *testing.T) {


### PR DESCRIPTION
Even if a search engine referrer contains a query param that is empty, it should still be considered a search engine referrer.

@mkobetic @charlescng @aSadhankar for review
