### PR TITLE
Add secure Yahoo and DuckDuckGo search support. Add locale specific social sites support

### DIFF
--- a/data/referrers.json
+++ b/data/referrers.json
@@ -3225,6 +3225,7 @@
                 "qc.search.yahoo.com",
                 "qc.yahoo.com",
                 "qc.yahoo.com",
+                "r.search.yahoo.com",
                 "se.search.yahoo.com",
                 "se.search.yahoo.com",
                 "se.yahoo.com",

--- a/data/search.csv
+++ b/data/search.csv
@@ -9,6 +9,7 @@ Baidu:baidu:wd
 Bing:bing:q
 CNN:cnn:query
 Daum:daum:q
+DuckDuckGo:duckduckgo:q,*
 Ekolay:ekolay:q
 Eniro:eniro:search_word
 Google:google:q,*
@@ -33,6 +34,6 @@ Terra:terra:query
 Virgilio:virgilio:qs
 Voila:voila:rdata
 Wirtulana Polska:wp:szukaj
-Yahoo!:yahoo:p
+Yahoo!:yahoo:p,*
 Yam:yam:k
 Yandex:yandex:text

--- a/referrer.go
+++ b/referrer.go
@@ -142,6 +142,16 @@ func parseSocial(rawUrl string, u *url.URL) *Social {
 	if rule, ok := SocialRules[u.Host]; ok {
 		return &Social{URL: rawUrl, Domain: rule.Domain, Label: rule.Label}
 	}
+
+	// Fuzzy search for things like es.reddit.com where the 2-letter locale is the subdomain
+	if len(u.Host) > 2 && u.Host[2] == '.' {
+		slicedHost := u.Host[3:]
+
+		if rule, ok := SocialRules[slicedHost]; ok {
+			return &Social{URL: rawUrl, Domain: rule.Domain, Label: rule.Label}
+		}
+	}
+
 	return nil
 }
 

--- a/referrer_test.go
+++ b/referrer_test.go
@@ -152,6 +152,30 @@ func TestSearchSiteGoogleWithQuery(t *testing.T) {
 	assert.Equal(t, engine.Query, "test")
 }
 
+func TestSearchSiteDuckDuckGoSecured(t *testing.T) {
+	url := `http://r.duckduckgo.com/l/?kh=-1&amp;uddg=http%3A%2F%2Fwww.shopify.com%2F`
+
+	r, err := Parse(url)
+	assert.NoError(t, err)
+
+	engine := r.(*Search)
+	assert.Equal(t, engine.Label, "DuckDuckGo")
+	assert.Equal(t, engine.Domain, "r.duckduckgo.com")
+	assert.Equal(t, engine.Query, "")
+}
+
+func TestSearchSiteYahooSecured(t *testing.T) {
+	url := `http://r.search.yahoo.com/_ylt=A0LEV0H.uiNTzEoA4UjBGOd_;_ylu=X3oDMTByMG04Z2o2BHNlYwNzcgRwb3MDMQRjb2xvA2JmMQR2dGlkAw--/RV=1/RE=1394936959/RO=10/RU=http%3a%2f%2fwww.shopify.com%2f/RS=^ADA0.VXK1194TBSbZf.fSErwtMSJrM-`
+
+	r, err := Parse(url)
+	assert.NoError(t, err)
+
+	engine := r.(*Search)
+	assert.Equal(t, engine.Label, "Yahoo!")
+	assert.Equal(t, engine.Domain, "r.search.yahoo.com")
+	assert.Equal(t, engine.Query, "")
+}
+
 func TestDirectSimple(t *testing.T) {
 	url := "http://example.com"
 
@@ -174,6 +198,18 @@ func TestSocialSimple(t *testing.T) {
 	assert.NotNil(t, social)
 	assert.Equal(t, social.Label, "Twitter")
 	assert.Equal(t, social.Domain, "twitter.com")
+}
+
+func TestSocialLanguageDomain(t *testing.T) {
+	url := "http://es.reddit.com/r/foo"
+
+	r, err := Parse(url)
+	assert.NoError(t, err)
+
+	social := r.(*Social)
+	assert.NotNil(t, social)
+	assert.Equal(t, social.Label, "Reddit")
+	assert.Equal(t, social.Domain, "reddit.com")
 }
 
 func TestSocialGooglePlus(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/Shopify/goreferrer/issues/11

Add rules to match:
- r.search.yahoo.com
- r.duckduckgo.com

Also, add a fuzzy match for locale specific server for social sites without explicit list of domains.
For example, recognize `es.reddit.com` as a social site.

@snormore @mkobetic 
/cc @Shopify/reports 
