### PR TITLE
Add support for new Facebook domain prefixes

### DIFF
--- a/referrer_test.go
+++ b/referrer_test.go
@@ -256,6 +256,38 @@ func TestSocialWithPrefixM(t *testing.T) {
 	assert.Equal(t, social.Domain, "facebook.com")
 }
 
+func TestSocialWithPrefixL(t *testing.T) {
+	url := "https://l.facebook.com/"
+
+	r, err := Parse(url)
+	assert.NoError(t, err)
+
+	social, ok := r.(*Social)
+	if !ok {
+		assert.Fail(t, "Expected Social", "Instead got %#v", r)
+		return
+	}
+	assert.NotNil(t, social)
+	assert.Equal(t, social.Label, "Facebook")
+	assert.Equal(t, social.Domain, "facebook.com")
+}
+
+func TestSocialWithPrefixLM(t *testing.T) {
+	url := "https://lm.facebook.com/"
+
+	r, err := Parse(url)
+	assert.NoError(t, err)
+
+	social, ok := r.(*Social)
+	if !ok {
+		assert.Fail(t, "Expected Social", "Instead got %#v", r)
+		return
+	}
+	assert.NotNil(t, social)
+	assert.Equal(t, social.Label, "Facebook")
+	assert.Equal(t, social.Domain, "facebook.com")
+}
+
 func TestEmailSimple(t *testing.T) {
 	url := "https://mail.google.com/9aifaufasodf8usafd"
 

--- a/rules.go
+++ b/rules.go
@@ -78,7 +78,7 @@ func mappedSocialRules(rawRules RuleSet) map[string]SocialRule {
 	for label, rawRule := range rawRules {
 		for _, domain := range rawRule["domains"] {
 			mappedRules[domain] = SocialRule{Label: label, Domain: domain}
-			for _, prefix := range []string{"www.", "m."} {
+			for _, prefix := range []string{"www.", "m.", "l.", "lm."} {
 				variation := prefix + domain
 				mappedRules[variation] = SocialRule{Label: label, Domain: domain}
 			}


### PR DESCRIPTION
Facebook now uses `l.facebook.com` and `lm.facebook.com` as domain names.

@snormore @mkobetic 
