### PR TITLE
Fix empty RegisteredDomain()

### DIFF
--- a/referrer.go
+++ b/referrer.go
@@ -41,7 +41,11 @@ type Referrer struct {
 }
 
 func (r *Referrer) RegisteredDomain() string {
-	return r.Domain + "." + r.Tld
+	if r.Domain != "" && r.Tld != "" {
+		return r.Domain + "." + r.Tld
+	}
+
+	return ""
 }
 
 func (r *Referrer) Host() string {


### PR DESCRIPTION
Calling `Referrer.RegisteredDomain()` when the domain and TLD aren't set returns `"."`.  Let's return an empty string to better communicate that we don't have this information.

@snormore 