### PR TITLE
Prioritize referrer over user agent

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -101,10 +101,6 @@ func (r RuleSet) ParseWith(URL string, domains []string, agent string) Referrer 
 		u.RegisteredDomain(),
 	}
 
-	if uaDomain := uaRule.RegisteredDomain(); uaDomain != "" {
-		variations = append(variations, uaDomain)
-	}
-
 	for _, host := range variations {
 		domainRule, exists := r.DomainRules[host]
 		if !exists {

--- a/rules_test.go
+++ b/rules_test.go
@@ -451,3 +451,29 @@ func TestNoScheme(t *testing.T) {
 	}
 	assert.Equal(t, expected, actual)
 }
+
+func TestSocialUAWithReferrer(t *testing.T) {
+	actual := DefaultRules.ParseWith("https://www.example.org/products/my-leggings?s=1", nil, "Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG-SM-N910A Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/122.0.0.17.71;]")
+	expected := Referrer{
+		Type:      Indirect,
+		Label:     "Example",
+		URL:       "https://www.example.org/products/my-leggings?s=1",
+		Subdomain: "www",
+		Domain:    "example",
+		Tld:       "org",
+		Path:      "/products/my-leggings",
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestSocialUAWithoutReferrer(t *testing.T) {
+	actual := DefaultRules.ParseWith("", nil, "Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG-SM-N910A Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/127.0.0.1;]")
+	expected := Referrer{
+		Type:   Social,
+		Label:  "Facebook",
+		URL:    "facebook://facebook.com",
+		Domain: "facebook",
+		Tld:    "com",
+	}
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Given a user agent such as Facebook:

1. If there's a referrer URL given, then use that URL as the referrer.
2. If there's no referrer URL given, then use Facebook as the referrer.

cc @Shopify/analytics-stack 