### PR TITLE
added gclid to google search classification

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -118,7 +118,7 @@ func (r RuleSet) ParseWith(URL string, domains []string, agent string) Referrer 
 		ref.Type = domainRule.Type
 		ref.Label = domainRule.Label
 		ref.Query = query
-		ref.GoogleType = googleSearchType(ref)
+		ref.GoogleType = googleSearchType(u.URL, ref)
 		return ref
 	}
 
@@ -147,31 +147,20 @@ func getQuery(values url.Values, params []string) string {
 	return ""
 }
 
-func googleSearchType(ref Referrer) GoogleSearchType {
+func googleSearchType(u *url.URL, ref Referrer) GoogleSearchType {
 	if ref.Type != Search || !strings.Contains(ref.Label, "Google") {
 		return NotGoogleSearch
 	}
 
-	if strings.HasPrefix(ref.Path, "/aclk") || strings.HasPrefix(ref.Path, "/pagead/aclk") || hasGCLID(ref.URL) {
+	if strings.HasPrefix(ref.Path, "/aclk") || strings.HasPrefix(ref.Path, "/pagead/aclk") || hasGCLID(u) {
 		return Adwords
 	}
 
 	return OrganicSearch
 }
 
-func hasGCLID(rawURL string) bool {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return false
-	}
-
-	m, err := url.ParseQuery(u.RawQuery)
-	if err != nil {
-		return false
-	}
-
-	_, ok := m["gclid"]
-
+func hasGCLID(u *url.URL) bool {
+	_, ok := u.Query()["gclid"]
 	return ok
 }
 

--- a/rules.go
+++ b/rules.go
@@ -152,7 +152,7 @@ func googleSearchType(ref Referrer) GoogleSearchType {
 		return NotGoogleSearch
 	}
 
-	if strings.HasPrefix(ref.Path, "/aclk") || strings.HasPrefix(ref.Path, "/pagead/aclk") {
+	if strings.HasPrefix(ref.Path, "/aclk") || strings.HasPrefix(ref.Path, "/pagead/aclk") || strings.Contains(ref.URL, "gclid=") {
 		return Adwords
 	}
 

--- a/rules.go
+++ b/rules.go
@@ -152,11 +152,27 @@ func googleSearchType(ref Referrer) GoogleSearchType {
 		return NotGoogleSearch
 	}
 
-	if strings.HasPrefix(ref.Path, "/aclk") || strings.HasPrefix(ref.Path, "/pagead/aclk") || strings.Contains(ref.URL, "gclid=") {
+	if strings.HasPrefix(ref.Path, "/aclk") || strings.HasPrefix(ref.Path, "/pagead/aclk") || hasGCLID(ref.URL) {
 		return Adwords
 	}
 
 	return OrganicSearch
+}
+
+func hasGCLID(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+
+	m, err := url.ParseQuery(u.RawQuery)
+	if err != nil {
+		return false
+	}
+
+	_, ok := m["gclid"]
+
+	return ok
 }
 
 func cleanPath(path string) string {

--- a/rules_test.go
+++ b/rules_test.go
@@ -335,6 +335,22 @@ func TestSearchGoogleAdwords(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestSearchGoogleWithGclid(t *testing.T) {
+	actual := DefaultRules.Parse("https://www.google.co.in/url?gclid=foo&sa=t&rct=j&q=test&esrc=s&source=web&cd=1&ved=0CDkQFjAA&url=http%3A%2F%2Fwww.yellowfashion.in%2F&ei=aZCPUtXmLcGQrQepkIHACA&usg=AFQjCNE-R5-7CENi9oqYe4vG-0g0E7nCSQ&bvm=bv.56988011,d.bmk")
+	expected := Referrer{
+		Type:       Search,
+		Label:      "Google",
+		URL:        "https://www.google.co.in/url?gclid=foo&sa=t&rct=j&q=test&esrc=s&source=web&cd=1&ved=0CDkQFjAA&url=http%3A%2F%2Fwww.yellowfashion.in%2F&ei=aZCPUtXmLcGQrQepkIHACA&usg=AFQjCNE-R5-7CENi9oqYe4vG-0g0E7nCSQ&bvm=bv.56988011,d.bmk",
+		Subdomain:  "www",
+		Domain:     "google",
+		Tld:        "co.in",
+		Path:       "/url",
+		Query:      "test",
+		GoogleType: Adwords,
+	}
+	assert.Equal(t, expected, actual)
+}
+
 func TestSearchGooglePageAd(t *testing.T) {
 	actual := DefaultRules.Parse("http://www.googleadservices.com/pagead/aclk?sa=l&q=flowers&ohost=www.google.com")
 	expected := Referrer{


### PR DESCRIPTION
Add [gclid](https://support.google.com/analytics/answer/2938246?hl=en) to Google search type classification criteria.

