### PR TITLE
Use a default of http scheme

### DIFF
--- a/rich_url.go
+++ b/rich_url.go
@@ -15,13 +15,18 @@ type richUrl struct {
 }
 
 func parseRichUrl(s string) (*richUrl, bool) {
-	if strings.Index(s, "://") == -1 {
-		s = "http://" + s
-	}
-
 	u, err := url.Parse(s)
 	if err != nil {
 		return nil, false
+	}
+
+	// assume a default scheme of http://
+	if u.Scheme == "" {
+		s = "http://" + s
+		u, err = url.Parse(s)
+		if err != nil {
+			return nil, false
+		}
 	}
 
 	tld, _ := publicsuffix.PublicSuffix(u.Host)

--- a/rules_test.go
+++ b/rules_test.go
@@ -477,3 +477,17 @@ func TestSocialUAWithoutReferrer(t *testing.T) {
 	}
 	assert.Equal(t, expected, actual)
 }
+
+func TestSocialWithUrlInParam(t *testing.T) {
+	actual := DefaultRules.Parse("l.facebook.com/l.php?u=https://packershoes.com/products/air-jordan-11-retro-low-cool-grey\u0026h=ATPh0cYTPh869ZnMyg6tSQnX_hmfIbuaXxm711cu2PReoCnTmmuyt_zoPko_HuPZIYvykPXmd_88e0-cwU5SverRebM-8WzFB0JJCi8p0aD3RjHQIMNoM7qoPd4pWA")
+	expected := Referrer{
+		Type:      Social,
+		Label:     "Facebook",
+		URL:       "l.facebook.com/l.php?u=https://packershoes.com/products/air-jordan-11-retro-low-cool-grey\u0026h=ATPh0cYTPh869ZnMyg6tSQnX_hmfIbuaXxm711cu2PReoCnTmmuyt_zoPko_HuPZIYvykPXmd_88e0-cwU5SverRebM-8WzFB0JJCi8p0aD3RjHQIMNoM7qoPd4pWA",
+		Subdomain: "l",
+		Domain:    "facebook",
+		Tld:       "com",
+		Path:      "/l.php",
+	}
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
Found a bug with referrer handling when the url is invalid. Can play with the fix [here](https://play.golang.org/p/oqeSNNZo1M7)

@Shopify/analytics-stack for review