### PR TITLE
Add TikTok as social referrer

### DIFF
--- a/default_rules.go
+++ b/default_rules.go
@@ -2634,7 +2634,7 @@ const defaultRules = `
             "parameters": [
                 "q"
             ]
-        }, 
+        },
         "Info": {
             "domains": [
                 "info.com"
@@ -2642,7 +2642,7 @@ const defaultRules = `
             "parameters": [
                 "qkw"
             ]
-        }, 
+        },
         "Interia": {
             "domains": [
                 "www.google.interia.pl"
@@ -4009,6 +4009,11 @@ const defaultRules = `
         "Taringa!": {
             "domains": [
                 "taringa.net"
+            ]
+        },
+        "TikTok": {
+            "domains": [
+                "tiktok.com"
             ]
         },
         "Tuenti": {


### PR DESCRIPTION
Simply adds tiktok as a social referrer. 

This is already being done in https://github.com/Shopify/pyreferrer/blob/master/pyreferrer/data/referrers.json#L4037

Relates to the issue https://github.com/Shopify/merchant-data-model/issues/619 
and https://github.com/Shopify/3p-Channels/issues/365