### PR TITLE
adding snapchat as social referrer

### DIFF
--- a/default_rules.go
+++ b/default_rules.go
@@ -3976,6 +3976,11 @@ const defaultRules = `
                 "skyrock.com"
             ]
         },
+		"Snapchat": {
+			"domains": [
+				"snapchat.com"
+			]
+		},
         "Sonico.com": {
             "domains": [
                 "sonico.com"


### PR DESCRIPTION
Snapchat is a social referer used by many merchants, [but we don't show them in the "Referrals from a social source"](https://discourse.shopify.io/t/referral-traffic-from-social-sources-including-marketing-channels/13547/2). 

We're tracking the issue [here](https://github.com/Shopify/core-issues/issues/23461) and [here](https://github.com/Shopify/3p-Channels/issues/365). 

We're finally [updating our referrer list to add tiktok](https://github.com/Shopify/goreferrer/pull/32), so taking this opportunity to also add snapchat as a referrer.

